### PR TITLE
Rename Navbar Link and Fix AI Task Generation Bug

### DIFF
--- a/client/src/components/HeaderNavbar.vue
+++ b/client/src/components/HeaderNavbar.vue
@@ -115,7 +115,7 @@ onMounted(() => {
             <RouterLink
                 :to="{ name: 'TimeTrackingOverview' }"
                 class="hover:text-blue-600 dark:hover:text-yellow-300 transition duration-100">
-              Mes imputations
+              Imputations
             </RouterLink>
           </li>
           <li>
@@ -241,7 +241,7 @@ onMounted(() => {
           <RouterLink
               :to="{ name: 'TimeTrackingOverview' }"
               class="block py-2 text-gray-800 dark:text-white hover:text-blue-600 dark:hover:text-yellow-300 transition duration-300">
-            Mes imputations
+            Imputations
           </RouterLink>
         </li>
         <li>

--- a/client/src/components/ToDoList/AIGenerateTasks.vue
+++ b/client/src/components/ToDoList/AIGenerateTasks.vue
@@ -32,7 +32,7 @@ const generateWithAI = async () => {
       for (const taskTitle of generatedTasks) {
         const newItem = { title: taskTitle, done: false };
         const response = await executeRequest(
-            () => client.postWithFile(`/api/todolist/${props.toDoListId}/todoitem`, newItem)
+            () => client.post(`/api/todolist/${props.toDoListId}/todoitem`, newItem)
         );
         newItems.push(response.toDoItem);
       }


### PR DESCRIPTION
I have completed the requested changes:
1. Renamed "Mes imputations" to "Imputations" in the header navbar.
2. Fixed the bug where AI task generation would return an "invalid input" (400 Bad Request) error. The issue was that the frontend was sending the task data as `multipart/form-data` instead of `application/json`, which didn't match the expected format on the server.

---
*PR created automatically by Jules for task [2440339957210551077](https://jules.google.com/task/2440339957210551077) started by @Florent-V*